### PR TITLE
Fixes to Ax tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ download:
 
 
 docs:
+	make download
 	make html
 	rm -rf docs
 	cp -r $(BUILDDIR)/html docs

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ download:
 
 
 docs:
-	make download
 	make html
 	rm -rf docs
 	cp -r $(BUILDDIR)/html docs

--- a/beginner_source/ax_multiobjective_nas_tutorial.py
+++ b/beginner_source/ax_multiobjective_nas_tutorial.py
@@ -332,7 +332,7 @@ experiment = Experiment(
 #
 
 
-total_trials = 48  # total evaluation budget
+total_trials = 8  # total evaluation budget
 
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 

--- a/beginner_source/ax_multiobjective_nas_tutorial.py
+++ b/beginner_source/ax_multiobjective_nas_tutorial.py
@@ -332,7 +332,7 @@ experiment = Experiment(
 #
 
 
-total_trials =  48 # total evaluation budget
+total_trials = 48 # total evaluation budget
 
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 

--- a/beginner_source/ax_multiobjective_nas_tutorial.py
+++ b/beginner_source/ax_multiobjective_nas_tutorial.py
@@ -34,7 +34,7 @@ This tutorial makes use of the following PyTorch libraries:
 # -----------------------
 #
 # Our goal is to optimize the PyTorch Lightning training job defined
-# in `mnist_train_nas.py <https://github.com/pytorch/tutorials/tree/master/beginner_source/mnist_train_nas.py`__.
+# in `mnist_train_nas.py <https://github.com/pytorch/tutorials/tree/master/beginner_source/mnist_train_nas.py>`__.
 # To do this using TorchX, we write a helper function that takes in
 # the values of the architcture and hyperparameters of the training
 # job and creates a TorchX AppDef (see the
@@ -299,9 +299,9 @@ opt_config = MultiObjectiveOptimizationConfig(
 # Creating the Ax Experiment
 # --------------------------
 #
-# In Ax, the `Experiment` object is the object that stores all the
-# information about the problem setup (`Experiment`s can be serialized
-# to JSON or stored to a databse backend such as MySQL in order to
+# In Ax, the ``Experiment`` object is the object that stores all the
+# information about the problem setup (``Experiment``s can be serialized
+# to JSON or stored to a database backend such as MySQL in order to
 # persist and be available to load on different machines - we won't
 # be using this functionality in this tutorial though).
 #
@@ -319,10 +319,10 @@ experiment = Experiment(
 # Choosing the GenerationStrategy
 # -------------------------------
 #
-# A `GenerationStrategy` is the abstract representation of how we
+# A ``GenerationStrategy`` is the abstract representation of how we
 # would like to perform the optimization. While this can be customized
 # (if you’d like to do so, see
-# `this tutorial <https://ax.dev/tutorials/generation_str ategy.html>`___),
+# `this tutorial <https://ax.dev/tutorials/generation_strategy.html>`_),
 # in most cases Ax can automatically determine an appropriate strategy
 # based on the search space, optimization config, and the total number
 # of trials we want to run.
@@ -456,7 +456,7 @@ _pareto_frontier_scatter_2d_plotly(experiment)
 #
 
 from ax.modelbridge.cross_validation import compute_diagnostics, cross_validate
-from ax.plot.diagnostic import interact_cross_validation
+from ax.plot.diagnostic import interact_cross_validation_plotly
 from ax.utils.notebook.plotting import init_notebook_plotting, render
 
 # # initialize some plotting code for plotting in notebooks
@@ -465,7 +465,7 @@ from ax.utils.notebook.plotting import init_notebook_plotting, render
 # The surrogate model is stored on the GenerationStrategy
 cv = cross_validate(gs.model)
 diagnostics = compute_diagnostics(cv)
-render(interact_cross_validation(cv))
+interact_cross_validation_plotly(cv)
 
 
 # TODO: Contour plots?
@@ -510,7 +510,7 @@ render(interact_cross_validation(cv))
 
 # cv = cross_validate(model_saas)
 # diagnostics = compute_diagnostics(cv)
-# render(interact_cross_validation(cv))
+# interact_cross_validation_plotly(cv)
 
 
 ######################################################################

--- a/beginner_source/ax_multiobjective_nas_tutorial.py
+++ b/beginner_source/ax_multiobjective_nas_tutorial.py
@@ -332,7 +332,7 @@ experiment = Experiment(
 #
 
 
-total_trials = 8  # total evaluation budget
+total_trials =  48 # total evaluation budget
 
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 

--- a/beginner_source/mnist_train_nas.py
+++ b/beginner_source/mnist_train_nas.py
@@ -140,7 +140,6 @@ trainer = Trainer(
     gpus=AVAIL_GPUS,
     max_epochs=args.epochs,
     enable_progress_bar=False,
-    weights_summary=None,
     deterministic=True,  # Do we want a bit of noise?
     default_root_dir=args.log_path,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ spacy==3.4.1
 ray[tune]
 tensorboard
 jinja2==3.0.3
-pytorch-lightning
+pytorch-lightning==1.6.4
 torchx
 ax-platform
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,10 @@ spacy==3.4.1
 ray[tune]
 tensorboard
 jinja2==3.0.3
-pytorch-lightning==1.6.4
+pytorch-lightning
 torchx
 ax-platform
+nbformat>=4.2.0
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
# Fixed:
* removed `weights_summary` argument from call to `pytorch_lightning.Trainer` for compatibility with newer version of lightning
* Added `nbformat>=4.2.0` as a dependency (we were getting an error saying this was required). This and the previous change seemed to fix the Pareto plot.
* `interact_cross_validation` -> `interact_cross_validation_plotly` to fix CV plot
* Corrected links
* Changed single-backticks to double to prevent rst warnings (single ticks sometimes cause things to render wrong and sometimes don't)

Note: run on MacOS with Python 3.10

# Not fixed:
* `make_docs` seems to fail ~1/3 of the time with the following error:
```
Unexpected failing examples:
/Users/santorella/repos/tutorials/beginner_source/ax_multiobjective_nas_tutorial.py failed leaving traceback:
Traceback (most recent call last):
  File "/Users/santorella/repos/tutorials/beginner_source/ax_multiobjective_nas_tutorial.py", line 442, in <module>
    _pareto_frontier_scatter_2d_plotly(experiment)
  File "/Users/santorella/opt/anaconda3/envs/tutorialsdev/lib/python3.10/site-packages/ax/service/utils/report_utils.py", line 584, in _pareto_frontier_scatter_2d_plotly
    return scatter_plot_with_pareto_frontier_plotly(
  File "/Users/santorella/opt/anaconda3/envs/tutorialsdev/lib/python3.10/site-packages/ax/plot/pareto_frontier.py", line 129, in scatter_plot_with_pareto_frontier_plotly
    extra_point_x = min(Y_pareto[:, 0]) if minimize[0] else max(Y_pareto[:, 0])
ValueError: max() arg is an empty sequence
```
* **Important**: I had thought that adding `nbformat` as a dependency fixed the Pareto plot, but now knowing that that plot is flaky, I want to confirm that `nbformat` is actually necessary.
* I've been getting the following error and I'm not sure why:
```
/Users/santorella/repos/tutorials/src/pytorch-sphinx-theme/docs/index.rst:1: CRITICAL: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'src/pytorch-sphinx-theme/README.rst'.
```

# Test plan
[x] Run with 48 trials and share screenshot or html of output (currently running)
<img width="832" alt="image" src="https://user-images.githubusercontent.com/9137425/183217384-416c728d-e1b5-4dfd-96fc-ee6583f0e3d3.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/9137425/183217405-eb127197-6964-46e1-bc8b-7b6a153ea14a.png">
[ ] Try running this in different conda environment to see if it will work without the new dependency `nbformat`
[ ] Understand why the Pareto plot is flaky -- either confirm that this is due to using only 8 trials or find a way to prevent it from failing.